### PR TITLE
Streak alerts

### DIFF
--- a/src/app/dashboard/_components/listening-streaks.tsx
+++ b/src/app/dashboard/_components/listening-streaks.tsx
@@ -13,6 +13,7 @@ import { Flame } from "lucide-react";
 import { unstable_cacheLife as cacheLife } from "next/cache";
 import Image from "next/image";
 import Link from "next/link";
+import { StreakNotExtendedTooltip } from "@/components/streak";
 import "server-only";
 
 type StreakItem = {
@@ -20,6 +21,7 @@ type StreakItem = {
     name: string;
     imageUrl: string;
     streak: number;
+    isExtendedToday: boolean;
 };
 
 /**
@@ -104,6 +106,7 @@ export async function ArtistStreaks({
         name: streak.name ?? "",
         imageUrl: streak.imageUrl ?? "",
         streak: streak.streakLength,
+        isExtendedToday: streak.isExtendedToday,
     }));
 
     return (
@@ -150,7 +153,7 @@ export async function ArtistStreaks({
                         <TableRow key={item.id}>
                             <TableCell>
                                 <Link
-                                    className="flex min-h-10 items-start gap-1 text-wrap underline-offset-4 hover:underline xs:gap-3 sm:min-h-12 sm:gap-4"
+                                    className="flex min-h-10 items-center gap-1 text-wrap underline-offset-4 hover:underline xs:gap-3 sm:min-h-12 sm:gap-4"
                                     href={`https://open.spotify.com/artist/${item.id}`}
                                     target="_blank"
                                 >
@@ -160,10 +163,10 @@ export async function ArtistStreaks({
                                             alt={item.name}
                                             width={48}
                                             height={48}
-                                            className="h-10 w-10 flex-shrink-0 xs:h-12 xs:w-12"
+                                            className="h-10 w-10 flex-shrink-0 rounded-[2px] xs:h-12 xs:w-12 sm:rounded-[4px]"
                                         />
                                     ) : (
-                                        <div className="h-10 w-10 flex-shrink-0 bg-muted xs:h-12 xs:w-12"></div>
+                                        <div className="h-10 w-10 flex-shrink-0 rounded-[2px] bg-muted xs:h-12 xs:w-12 sm:rounded-[4px]"></div>
                                     )}
                                     <span className="line-clamp-2 break-words text-xs sm:text-sm">
                                         {item.name}
@@ -171,7 +174,10 @@ export async function ArtistStreaks({
                                 </Link>
                             </TableCell>
                             <TableCell>
-                                <span className="text-xs sm:text-sm">
+                                <span className="flex flex-row items-center gap-1 text-xs sm:text-sm">
+                                    {!item.isExtendedToday ? (
+                                        <StreakNotExtendedTooltip />
+                                    ) : null}
                                     {item.streak} days
                                 </span>
                             </TableCell>
@@ -215,6 +221,7 @@ export async function TrackStreaks({
         name: streak.name ?? "",
         imageUrl: streak.imageUrl ?? "",
         streak: streak.streakLength,
+        isExtendedToday: streak.isExtendedToday,
     }));
 
     return (
@@ -261,7 +268,7 @@ export async function TrackStreaks({
                         <TableRow key={item.id}>
                             <TableCell>
                                 <Link
-                                    className="flex min-h-10 items-start gap-1 text-wrap underline-offset-4 hover:underline xs:gap-3 sm:min-h-12 sm:gap-2"
+                                    className="flex min-h-10 items-center gap-1 text-wrap underline-offset-4 hover:underline xs:gap-3 sm:min-h-12 sm:gap-2"
                                     href={`https://open.spotify.com/track/${item.id}`}
                                     target="_blank"
                                 >
@@ -271,10 +278,10 @@ export async function TrackStreaks({
                                             alt={item.name}
                                             width={48}
                                             height={48}
-                                            className="h-10 w-10 flex-shrink-0 xs:h-12 xs:w-12"
+                                            className="h-10 w-10 flex-shrink-0 rounded-[2px] xs:h-12 xs:w-12 sm:rounded-[4px]"
                                         />
                                     ) : (
-                                        <div className="h-10 w-10 flex-shrink-0 bg-muted xs:h-12 xs:w-12"></div>
+                                        <div className="h-10 w-10 flex-shrink-0 rounded-[2px] bg-muted xs:h-12 xs:w-12 sm:rounded-[4px]"></div>
                                     )}
                                     <span className="line-clamp-2 break-words text-xs sm:text-sm">
                                         {item.name}
@@ -282,7 +289,10 @@ export async function TrackStreaks({
                                 </Link>
                             </TableCell>
                             <TableCell>
-                                <span className="text-xs sm:text-sm">
+                                <span className="flex flex-row items-center gap-1 text-xs sm:text-sm">
+                                    {!item.isExtendedToday ? (
+                                        <StreakNotExtendedTooltip />
+                                    ) : null}
                                     {item.streak} days
                                 </span>
                             </TableCell>
@@ -326,6 +336,7 @@ export async function AlbumStreaks({
         name: streak.name ?? "",
         imageUrl: streak.imageUrl ?? "",
         streak: streak.streakLength,
+        isExtendedToday: streak.isExtendedToday,
     }));
 
     return (
@@ -372,7 +383,7 @@ export async function AlbumStreaks({
                         <TableRow key={item.id}>
                             <TableCell>
                                 <Link
-                                    className="flex min-h-10 items-start gap-1 text-wrap underline-offset-4 hover:underline xs:gap-3 sm:min-h-12 sm:gap-2"
+                                    className="flex min-h-10 items-center gap-1 text-wrap underline-offset-4 hover:underline xs:gap-3 sm:min-h-12 sm:gap-2"
                                     href={`https://open.spotify.com/album/${item.id}`}
                                     target="_blank"
                                 >
@@ -382,10 +393,10 @@ export async function AlbumStreaks({
                                             alt={item.name}
                                             width={48}
                                             height={48}
-                                            className="h-10 w-10 flex-shrink-0 xs:h-12 xs:w-12"
+                                            className="h-10 w-10 flex-shrink-0 rounded-[2px] xs:h-12 xs:w-12 sm:rounded-[4px]"
                                         />
                                     ) : (
-                                        <div className="h-10 w-10 flex-shrink-0 bg-muted xs:h-12 xs:w-12"></div>
+                                        <div className="h-10 w-10 flex-shrink-0 rounded-[2px] bg-muted xs:h-12 xs:w-12 sm:rounded-[4px]"></div>
                                     )}
                                     <span className="line-clamp-2 break-words text-xs sm:text-sm">
                                         {item.name}
@@ -393,7 +404,10 @@ export async function AlbumStreaks({
                                 </Link>
                             </TableCell>
                             <TableCell>
-                                <span className="text-xs sm:text-sm">
+                                <span className="flex flex-row items-center gap-1 text-xs sm:text-sm">
+                                    {!item.isExtendedToday ? (
+                                        <StreakNotExtendedTooltip />
+                                    ) : null}
                                     {item.streak} days
                                 </span>
                             </TableCell>
@@ -434,7 +448,12 @@ export async function OverallListeningStreak({ userId }: { userId: string }) {
                 <Flame className="h-4 w-4 text-orange-500 sm:h-5 sm:w-5" />
             </div>
             <div>
-                <div className="text-lg font-bold sm:text-xl">{streak}</div>
+                <div className="flex flex-row items-center gap-1 text-lg font-bold sm:text-xl">
+                    {streak}
+                    {!result?.get(userId)?.isExtendedToday ? (
+                        <StreakNotExtendedTooltip />
+                    ) : null}
+                </div>
                 <div className="text-xs text-muted-foreground">
                     {streak === 1 ? "day" : "days"} in a row
                 </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -199,7 +199,9 @@ export default async function DashboardPage({
     return (
         <div className="p-2 sm:p-4">
             <h1 className="mb-2 text-xl font-bold sm:text-2xl">
-                Dashboard{clerkUser ? ` for ${clerkUser.firstName}` : ""}
+                {clerkUser
+                    ? `${clerkUser.firstName}${clerkUser.firstName?.endsWith("s") ? "'" : "'s"} Dashboard`
+                    : "Dashboard"}
             </h1>
             <DateSelector
                 baseUrl={getBaseUrl()}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -87,7 +87,8 @@ export default async function DashboardPage({
         userId = currentUserId;
     } else if (userId !== currentUserId) {
         // Check if the users are friends
-        const areFriends = await usersAreFriends(currentUserId, userId);
+        const areFriends =
+            (await usersAreFriends(currentUserId, userId)) || true;
         if (!areFriends) {
             // Track access denied event
             await captureAuthenticatedEvent(

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -87,8 +87,7 @@ export default async function DashboardPage({
         userId = currentUserId;
     } else if (userId !== currentUserId) {
         // Check if the users are friends
-        const areFriends =
-            (await usersAreFriends(currentUserId, userId)) || true;
+        const areFriends = await usersAreFriends(currentUserId, userId);
         if (!areFriends) {
             // Track access denied event
             await captureAuthenticatedEvent(

--- a/src/app/leaderboard/_components/leaderboard-data-fetcher.tsx
+++ b/src/app/leaderboard/_components/leaderboard-data-fetcher.tsx
@@ -136,9 +136,9 @@ export async function getLeaderboardData(
 
         // Sort based on sortOrder
         if (sortOrder === "asc") {
-            streakEntries.sort((a, b) => b[1].streakLength - a[1].streakLength); // Sort descending
+            streakEntries.sort((a, b) => a[1].streakLength - b[1].streakLength); // Sort ascending
         } else {
-            streakEntries.sort((a, b) => a[1].streakLength - b[1].streakLength); // Sort descending
+            streakEntries.sort((a, b) => b[1].streakLength - a[1].streakLength); // Sort descending
         }
 
         // Apply pagination

--- a/src/app/leaderboard/_components/leaderboard-table.tsx
+++ b/src/app/leaderboard/_components/leaderboard-table.tsx
@@ -1,4 +1,5 @@
 import { PercentageBadge } from "@/components/percentage-badge";
+import { StreakNotExtendedTooltip } from "@/components/streak";
 import {
     Table,
     TableBody,
@@ -29,6 +30,7 @@ interface LeaderboardUser {
     playtime?: number;
     count?: number;
     streak?: number;
+    streakIsExtendedToday: boolean;
     percentChange: number | null;
     rankChange: number | null;
     previousRank: number | null;
@@ -207,7 +209,7 @@ export default async function LeaderboardTable({
                                 {/* Metrics in the same order as headers */}
                                 {orderedMetrics.map((metric) => {
                                     const metricType = metric.type as SortBy;
-                                    let displayValue = "";
+                                    let displayValue: React.ReactNode = "";
 
                                     // Get the correct value for this metric
                                     if (metricType === "Playtime") {
@@ -220,7 +222,17 @@ export default async function LeaderboardTable({
                                         ).toLocaleString();
                                     } else {
                                         // Streak
-                                        displayValue = `${Number(user.streak ?? 0).toLocaleString()} days`;
+                                        displayValue = (
+                                            <div className="flex flex-row items-center gap-1">
+                                                {!user.streakIsExtendedToday ? (
+                                                    <StreakNotExtendedTooltip />
+                                                ) : null}
+                                                {Number(
+                                                    user.streak ?? 0,
+                                                ).toLocaleString()}{" "}
+                                                days
+                                            </div>
+                                        );
                                     }
 
                                     return (

--- a/src/components/now-playing-widget.tsx
+++ b/src/components/now-playing-widget.tsx
@@ -345,7 +345,7 @@ function NowPlayingWidgetInner() {
                                         }}
                                     >
                                         <Image
-                                            src="/spotify-assets/Spotify_Icon_RGB_Green.png"
+                                            src="/spotify-assets/Spotify_Icon_RGB_White.png"
                                             alt="Spotify"
                                             width={21}
                                             height={21}

--- a/src/components/streak.tsx
+++ b/src/components/streak.tsx
@@ -1,0 +1,26 @@
+import { TriangleAlert } from "lucide-react";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export function StreakNotExtendedTooltip() {
+    return (
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger>
+                    <span className="flex items-center gap-1 text-yellow-500">
+                        <TriangleAlert className="h-4 w-4" />
+                    </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <p className="text-sm">
+                        This streak has not been extended today.
+                    </p>
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tooltips to streak displays indicating when a streak has not been extended today, visible on dashboard and leaderboard pages.
  - Improved dashboard page title formatting to better handle names ending with "s".
- **UI Improvements**
  - Enhanced styling for streak-related images and containers for a more consistent appearance.
  - Updated the Spotify icon in the Now Playing widget to a white version for better visual integration.
- **Bug Fixes**
  - Corrected leaderboard streak sorting for more accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->