### PR TITLE
Add better handling for streak end dates

### DIFF
--- a/src/app/dashboard/_components/listening-streaks.tsx
+++ b/src/app/dashboard/_components/listening-streaks.tsx
@@ -101,18 +101,20 @@ export async function GenericStreaks({
     type,
     limit = 100,
     isTabbed = false,
+    endDate,
 }: {
     userId: string;
     type: StreakType;
     limit?: number;
     isTabbed?: boolean;
+    endDate?: Date;
 }) {
     "use cache";
 
     cacheLife("hours");
 
     // Get streaks using the getUserStreaks function
-    let streaksData = await getUserStreaks(userId, limit, type);
+    let streaksData = await getUserStreaks(userId, limit, type, endDate);
 
     // Limit to only streaks with more than 1 day
     streaksData = streaksData.filter((streak) => streak.streakLength > 1);
@@ -244,11 +246,13 @@ export async function GenericStreaks({
 export async function ArtistStreaks({
     userId,
     limit = 100,
+    endDate,
 }: {
     userId: string;
     limit?: number;
+    endDate?: Date;
 }) {
-    return <GenericStreaks userId={userId} type="artist" limit={limit} />;
+    return <GenericStreaks userId={userId} type="artist" limit={limit} endDate={endDate} />;
 }
 
 /**
@@ -257,11 +261,13 @@ export async function ArtistStreaks({
 export async function TrackStreaks({
     userId,
     limit = 100,
+    endDate,
 }: {
     userId: string;
     limit?: number;
+    endDate?: Date;
 }) {
-    return <GenericStreaks userId={userId} type="track" limit={limit} />;
+    return <GenericStreaks userId={userId} type="track" limit={limit} endDate={endDate} />;
 }
 
 /**
@@ -270,23 +276,25 @@ export async function TrackStreaks({
 export async function AlbumStreaks({
     userId,
     limit = 100,
+    endDate,
 }: {
     userId: string;
     limit?: number;
+    endDate?: Date;
 }) {
-    return <GenericStreaks userId={userId} type="album" limit={limit} />;
+    return <GenericStreaks userId={userId} type="album" limit={limit} endDate={endDate} />;
 }
 
 /**
  * Server component to display overall listening streak
  */
-export async function OverallListeningStreak({ userId }: { userId: string }) {
+export async function OverallListeningStreak({ userId, endDate }: { userId: string; endDate?: Date }) {
     "use cache";
 
     cacheLife("hours");
 
     // Get the user's overall listening streak using the new function
-    const result = await getUsersOverallStreaks([userId]);
+    const result = await getUsersOverallStreaks([userId], endDate);
 
     // Use the streak length or default to 0 if no streak found
     const streak = result?.get(userId)?.streakLength ?? 0;

--- a/src/app/dashboard/_components/streak-tabs.tsx
+++ b/src/app/dashboard/_components/streak-tabs.tsx
@@ -5,9 +5,10 @@ import "server-only";
 
 interface StreakTabsProps {
     userId: string;
+    endDate?: Date;
 }
 
-export async function StreakTabs({ userId }: StreakTabsProps) {
+export async function StreakTabs({ userId, endDate }: StreakTabsProps) {
     "use cache";
     return (
         <Tabs defaultValue="artist" className="w-full">
@@ -28,6 +29,7 @@ export async function StreakTabs({ userId }: StreakTabsProps) {
                         userId={userId}
                         type="artist"
                         isTabbed={true}
+                        endDate={endDate}
                     />
                 </Suspense>
             </TabsContent>
@@ -37,6 +39,7 @@ export async function StreakTabs({ userId }: StreakTabsProps) {
                         userId={userId}
                         type="track"
                         isTabbed={true}
+                        endDate={endDate}
                     />
                 </Suspense>
             </TabsContent>
@@ -46,6 +49,7 @@ export async function StreakTabs({ userId }: StreakTabsProps) {
                         userId={userId}
                         type="album"
                         isTabbed={true}
+                        endDate={endDate}
                     />
                 </Suspense>
             </TabsContent>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -298,7 +298,7 @@ export default async function DashboardPage({
                     </CardHeader>
                     <CardContent className="p-3 pt-0 sm:p-4 sm:pt-0">
                         <Suspense fallback={<OverallListeningStreakSkeleton />}>
-                            <OverallListeningStreak userId={userId} />
+                            <OverallListeningStreak userId={userId} endDate={endDate} />
                         </Suspense>
                     </CardContent>
                 </Card>
@@ -316,7 +316,7 @@ export default async function DashboardPage({
                         </CardHeader>
                         <CardContent className="p-3 pt-0 sm:p-4 sm:pt-0">
                             <Suspense fallback={<StreakSkeleton />}>
-                                <StreakTabs userId={userId} />
+                                <StreakTabs userId={userId} endDate={endDate} />
                             </Suspense>
                         </CardContent>
                     </Card>
@@ -332,7 +332,7 @@ export default async function DashboardPage({
                         </CardHeader>
                         <CardContent className="p-3 pt-0 sm:p-4 sm:pt-0">
                             <Suspense fallback={<StreakSkeleton />}>
-                                <ArtistStreaks userId={userId} />
+                                <ArtistStreaks userId={userId} endDate={endDate} />
                             </Suspense>
                         </CardContent>
                     </Card>
@@ -345,7 +345,7 @@ export default async function DashboardPage({
                         </CardHeader>
                         <CardContent className="p-3 pt-0 sm:p-4 sm:pt-0">
                             <Suspense fallback={<StreakSkeleton />}>
-                                <TrackStreaks userId={userId} />
+                                <TrackStreaks userId={userId} endDate={endDate} />
                             </Suspense>
                         </CardContent>
                     </Card>
@@ -358,7 +358,7 @@ export default async function DashboardPage({
                         </CardHeader>
                         <CardContent className="p-3 pt-0 sm:p-4 sm:pt-0">
                             <Suspense fallback={<StreakSkeleton />}>
-                                <AlbumStreaks userId={userId} />
+                                <AlbumStreaks userId={userId} endDate={endDate} />
                             </Suspense>
                         </CardContent>
                     </Card>


### PR DESCRIPTION
Closes #26  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to filter listening streaks by a specific end date across all relevant dashboard components.
  * Users can now view artist, track, album, and overall listening streaks as of a chosen date, not just the current day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->